### PR TITLE
TypeError bug and other function return modifications

### DIFF
--- a/better_profanity/better_profanity.py
+++ b/better_profanity/better_profanity.py
@@ -175,13 +175,13 @@ class Profanity:
             next_words_indices = self._update_next_words_indices(
                 text, next_words_indices, index
             )
-            contains_swear_word, end_index = any_next_words_form_swear_word(
+            swear_word_result, end_index = any_next_words_form_swear_word(
                 cur_word, next_words_indices, self.CENSOR_WORDSET
             )
             # If censor_char is None, it implies whoever calls this function is only checking if swear words exists
-            if contains_swear_word:
+            if swear_word_result != "":
                 if censor_char is None:
-                    return cur_word
+                    return swear_word_result
                 cur_word = get_replacement_for_swear_word(censor_char)
                 skip_index = end_index
                 char = ""
@@ -199,6 +199,8 @@ class Profanity:
         # Final check
         if cur_word != "" and skip_index < len(text) - 1:
             if cur_word.lower() in self.CENSOR_WORDSET:
+                if censor_char is None:
+                    return cur_word
                 cur_word = get_replacement_for_swear_word(censor_char)
             censored_text += cur_word
         # If censor_char is None, it implies whoever calls this function is only checking if swear words exists

--- a/better_profanity/utils.py
+++ b/better_profanity/utils.py
@@ -41,6 +41,8 @@ def any_next_words_form_swear_word(cur_word, words_indices, censor_words):
             full_word_with_separators,
             word_with_separators.lower(),
         )
-        if full_word in censor_words or full_word_with_separators in censor_words:
-            return True, end_index
-    return False, -1
+        if full_word in censor_words:
+            return full_word, end_index
+        elif full_word_with_separators in censor_words:
+            return full_word_with_separators, end_index
+    return "", -1


### PR DESCRIPTION
Fixed a bug where having profanity as the last word yields TypeError.
Changed what the function `any_next_words_form_swear_word` returns. Instead of a bool and an int, it now returns a string and an int. This change intends to make integration into the main RateMDs code base more convenient.