### PR TITLE
Fix functionaity of add_censor_words()

### DIFF
--- a/better_profanity/better_profanity.py
+++ b/better_profanity/better_profanity.py
@@ -62,10 +62,9 @@ class Profanity:
                 "Function 'add_censor_words' only accepts list, tuple or set."
             )
         # Convert all arguments to lower case. Works for tuples and lists too from re-casting into sets
-        custom_words = {word.lower() for word in custom_words}
         custom_words_combos = set()
         for word in custom_words:
-            custom_words_combos.update(set(self._generate_patterns_from_word(word)))
+            custom_words_combos.update(set(self._generate_patterns_from_word(word.lower())))
         self.CENSOR_WORDSET.update(custom_words_combos)
 
     def contains_what_profanity(self, text):

--- a/better_profanity/better_profanity.py
+++ b/better_profanity/better_profanity.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from itertools import product
-
 from .constants import ALLOWED_CHARACTERS
 
 from .utils import (
@@ -16,14 +15,14 @@ class Profanity:
     def __init__(self):
         self.CENSOR_WORDSET = set()
         self.CHARS_MAPPING = {
-            "a": ("a", "@", "*", "4"),
-            "i": ("i", "*", "l", "1"),
-            "o": ("o", "*", "0", "@"),
-            "u": ("u", "*", "v"),
-            "v": ("v", "*", "u"),
-            "l": ("l", "1"),
-            "e": ("e", "*", "3"),
-            "s": ("s", "$", "5"),
+            "a": ("a", "@", "*", "4",),
+            "i": ("i", "*", "l", "1", "!",),
+            "o": ("o", "*", "0", "@",),
+            "u": ("u", "*", "v",),
+            "v": ("v", "*", "u",),
+            "l": ("l", "1", "!",),
+            "e": ("e", "*", "3",),
+            "s": ("s", "$", "5",),
             "t": ("t", "7",),
         }
         self.MAX_NUMBER_COMBINATIONS = 1
@@ -62,8 +61,12 @@ class Profanity:
             raise TypeError(
                 "Function 'add_censor_words' only accepts list, tuple or set."
             )
-
-        self.CENSOR_WORDSET.update(custom_words)
+        # Convert all arguments to lower case. Works for tuples and lists too from re-casting into sets
+        custom_words = {word.lower() for word in custom_words}
+        custom_words_combos = set()
+        for word in custom_words:
+            custom_words_combos.update(set(self._generate_patterns_from_word(word)))
+        self.CENSOR_WORDSET.update(custom_words_combos)
 
     def contains_what_profanity(self, text):
         """Return the first detected swear word of the input text and if not, it returns an empty string"""

--- a/better_profanity/constants.py
+++ b/better_profanity/constants.py
@@ -3,13 +3,12 @@
 from io import open
 from json import load
 from string import ascii_letters, digits
-
 from .utils import get_complete_path_of_file
 
 
 ALLOWED_CHARACTERS = set(ascii_letters)
 ALLOWED_CHARACTERS.update(set(digits))
-ALLOWED_CHARACTERS.update({"@", "$", "*", '"', "'"})
+ALLOWED_CHARACTERS.update({"@", "$", "*", '"', "'", "!", "+"})
 
 # Pre-load the unicode characters
 with open(get_complete_path_of_file("alphabetic_unicode.json"), "r") as json_file:


### PR DESCRIPTION
Fixed an issue where if any argument of add_censor_words() contains capitalized letters that word will not be detected by the filter in practice. 

> I.e.: If `add_censor_words(['testWord'])` is called, testWord will never be detected by the filter and so are all of its letter-replacement derivatives (including capitalization).

Arguments passed into add_censor_words will now be sensitive to letter-replacement derivatives

> Before: if 'dunce' is passed, 'dunc3' will not be picked up by the filter. Now: it does