### PR TITLE
"Last-char" edge case fix

### DIFF
--- a/better_profanity/better_profanity.py
+++ b/better_profanity/better_profanity.py
@@ -244,6 +244,11 @@ class Profanity:
                 next_word += char
                 continue
             break
+            # Breaks when the index points to a disallowed char (i.e. spacing char) immediately behind an allowed char
+        if next_word != "" and start_idx == index:
+            # Catch edge case where the last char of `text` is ONE allowed char preceded by spacing chars (i.e. ".x")
+            # `index` should've pointed to the index +1 to the allowed char, but points to the allowed char itself
+            index += 1
         return next_word, index
 
     def _get_next_words(self, text, start_idx, num_of_next_words=1):


### PR DESCRIPTION
Fix an edge case where a particular combination of banned word derivative will fool the filter to pass the comment as appropriate. If the only banned word is the last word of the sentence and the banned word is written with deliberate spacing char immediately before the last char and no spacing char after, the comment will pass.
For example:
"ass" 
-> "a.s.s" -> PASS
-> "a.ss" -> BAN (intended)
-> "as.s" -> PASS 
-> "as,. .._..,  ,.,. s" -> PASS
-> "a.s.s." -> BAN (intended, note the period is the last character)
-> "as.s       " -> PASS
-> "bas.s" -> PASS (intended)
-> "@\_$\_$" -> PASS
-> "@\_$$" -> BAN (intended)